### PR TITLE
Support for RC and BETA

### DIFF
--- a/pkgbasify.lua
+++ b/pkgbasify.lua
@@ -220,7 +220,7 @@ function base_repo_url()
 		fatal("Unsupported FreeBSD version: " .. raw)
 	end
 
-	if branch == "RELEASE" then
+	if branch == "RELEASE" or branch:match("^BETA") or branch:match("^RC") then
 		return "pkg+https://pkg.FreeBSD.org/${ABI}/base_release_" .. minor
 	elseif branch == "CURRENT" or branch == "STABLE" then
 		return "pkg+https://pkg.FreeBSD.org/${ABI}/base_latest"


### PR DESCRIPTION
Adding support for RC* and BETA*

[#15 ](https://github.com/FreeBSDFoundation/pkgbasify/issues/15)

This would help testing BETA and RC versions.